### PR TITLE
change default server address to miner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /usr/src/sx1302_hal
 ADD . /usr/src/sx1302_hal/
 
 RUN make clean && make
+RUN sed -i 's/localhost/miner/' /usr/src/sx1302_hal/packet_forwarder/global_conf.*
 
 FROM ${RUNNER_IMAGE} as runner
 


### PR DESCRIPTION
This change defaults to the hostname "miner" for the server_address in the config files in place of "localhost" which eliminates the need to run the pf with host networking or open udp port 1680 for the miner if using docker name resolution.