### PR TITLE
Remove SX130x version check since this HAL actually supports both SX1302 and SX1303

### DIFF
--- a/libloragw/src/loragw_reg.c
+++ b/libloragw/src/loragw_reg.c
@@ -1226,10 +1226,6 @@ int lgw_connect(const char * spidev_path) {
         DEBUG_MSG("ERROR READING CHIP VERSION REGISTER\n");
         return LGW_REG_ERROR;
     }
-    if (u != loregs[SX1302_REG_COMMON_VERSION_VERSION].dflt) {
-        DEBUG_PRINTF("ERROR: NOT EXPECTED CHIP VERSION (v%u)\n", u);
-        return LGW_REG_ERROR;
-    }
     DEBUG_PRINTF("Note: chip version is 0x%02X (v%u.%u)\n", u, (u >> 4) & 0x0F, u & 0x0F) ;
 
     DEBUG_MSG("Note: success connecting the concentrator\n");


### PR DESCRIPTION
Some sensecap's have a SX1303 instead of a SX1302.
This change would make this packet forwarder work on those sensecap's also.